### PR TITLE
適切なメニューの選択・金額が表示されるように修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -19,7 +19,8 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  # 配列は0からスタートするため、入力の数字から1を引く
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
@@ -30,5 +31,6 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+# Integer型にして計算
+total = FOODS[order1][:price].to_i + DRINKS[order2][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -32,5 +32,5 @@ puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
 # Integer型にして計算
-total = FOODS[order1][:price].to_i + DRINKS[order2][:price].to_i
+total = DRINKS[order1][:price].to_i + FOODS[order2][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
# プラクティス
https://bootcamp.fjord.jp/practices/230

# 問題点

- 頼んだつもりのメニューが選択できない。
- 最後の番号のメニューを選択するとエラーとなる。
- お会計額が異様に高い。
- 違う番号のドリンク、フードを注文したとき、お会計が正しくない。
  - 例: (1)コーヒー と (2)アップルパイを頼むと、お会計が意図した金額にならない。

# 原因と解決法

- 配列の番号は0から始まるが、入力された数字が1から始まるため、入力する値と参照する値がずれていたこと
  -  配列の参照を入力された数値から「−1」することで解決
- 合計金額は、数字のテキストをただ繋げて表示しているだけだった
  - Integer型にして計算することで、足し算になるようにして解決
- 最後のメニュー選択でエラーになるのは、`order1`と`order2`が参照する配列が異なっていたため
  - 正しい順序にすることで解決 

# 確認点
以下２点をご確認ください

1. 入力した数字で、正しい注文ができているか
2. 合計金額は正しく表示されているか
3. 最後のメニューを選んでも正しく結果が返ってくるか